### PR TITLE
Update Dockerfiles, pull-updates.sh, and README.md for EGI-330 and CS…

### DIFF
--- a/csc-385/Dockerfile
+++ b/csc-385/Dockerfile
@@ -4,6 +4,9 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH="/workspace/bin:${PATH}"
 
+# Set the working directory
+WORKDIR /workspace
+
 # Install dependencies and GitHub CLI (gh)
 RUN apt-get update && apt-get install -y git curl ca-certificates wget \
     && mkdir -p -m 755 /etc/apt/keyrings \

--- a/csc-385/README.md
+++ b/csc-385/README.md
@@ -10,7 +10,7 @@ This first stage will set up your GitHub repository and clone it to your local m
 
 First, you need to download the `Dockerfile` for the initialization process.
 
-[Download the Dockerfile here](https://raw.githubusercontent.com/edwjonesga/edwjones-ccu/main/classes/csc-385/Dockerfile)
+[Download the Dockerfile here](https://raw.githubusercontent.com/edwjonesga/ccu-classes/main/csc-385/Dockerfile)
 
 Save this file in a new, empty directory on your computer. Make sure the file is named `Dockerfile` with no extension.
 
@@ -67,10 +67,19 @@ This step will create your personal GitHub repository for this class and clone i
     ```
 
 4.  Run the initializer container, mounting your current directory into the container's `/workspace`:
-
-    ```sh
-    docker run -it --rm -v "$(pwd)":/workspace csc-385-init-env
-    ```
+    - **For Linux and Mac:**
+      ```sh
+      docker run -it --rm -v "$(pwd)":/workspace csc-385-init-env
+      ```
+    - **For Windows (using PowerShell):**
+      ```sh
+      docker run -it --rm -v "${PWD}:/workspace" csc-385-init-env
+      ```
+    - **For Windows (using Command Prompt):**
+      ```sh
+      docker run -it --rm -v "%cd%":/workspace csc-385-init-env
+      ```
+    > **Note for Linux Users:** You may need to run this command with `sudo`.
 
 5.  The container will run the `init.sh` script, which will guide you through the GitHub setup process. At the end, it will clone your new repository into the directory you are in and then exit.
 
@@ -92,6 +101,7 @@ After the initialization is complete, you will have a new directory containing y
     ```sh
     ./startContainer.sh
     ```
+    > **Note for Windows Users:** `/startContainer.sh` will not work so instead copy the same `docker run` command from step 4
 
 You will now be inside your development container, with all the necessary tools and your repository files mounted in the `/workspace` directory. Happy coding!
 

--- a/egi-330/README.md
+++ b/egi-330/README.md
@@ -23,7 +23,7 @@ If you don't already have Docker installed, please follow the instructions for y
 
 Download the `Dockerfile` from this repository and place it in a new, empty directory on your computer.
 
-[**Click here to download the Dockerfile**](https://raw.githubusercontent.com/edwjonesga/egi-330/main/Dockerfile)
+[**Click here to download the Dockerfile**](https://raw.githubusercontent.com/edwjonesga/ccu-classes/main/egi-330/Dockerfile)
 
 Make sure the downloaded file is named `Dockerfile` with no file extension.
 


### PR DESCRIPTION
…C-385

This commit updates the Dockerfiles, pull-updates.sh scripts, and README.md files for EGI-330 and CSC-385 to reference the new `edwjonesga/ccu-classes` repository.

- The `egi-330/bin/pull-updates.sh` script has been updated to clone the `ccu-classes` repository and copy the `egi-330` subdirectory.
- The `egi-330/Dockerfile` has been updated to clone the `ccu-classes` repository and copy the `egi-330` subdirectory during initialization.
- The `egi-330/README.md` has been updated with the correct Dockerfile download link.
- The `csc-385/Dockerfile` has been updated to clone the `ccu-classes` repository and copy the `csc-385` subdirectory during initialization. The init script now follows the same pattern as the EGI-330 init script, and the container's working directory is set to `/workspace`.
- A new `csc-385/bin/pull-updates.sh` script has been created to handle updates from the `ccu-classes` repository.
- The `csc-385/README.md` has been updated with the correct Dockerfile download link and machine-specific instructions for running Docker.