### PR TITLE
Update Dockerfiles, pull-updates.sh, and README.md for EGI-330 and CS…

### DIFF
--- a/csc-385/Dockerfile
+++ b/csc-385/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH="/workspace/bin:${PATH}"
 WORKDIR /workspace
 
 # Install dependencies and GitHub CLI (gh)
-RUN apt-get update && apt-get install -y git curl ca-certificates wget \
+RUN apt-get update && apt-get install -y git curl ca-certificates wget rsync \
     && mkdir -p -m 755 /etc/apt/keyrings \
     && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
     && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
…C-385

This commit updates the Dockerfiles, pull-updates.sh scripts, and README.md files for EGI-330 and CSC-385 to reference the new `edwjonesga/ccu-classes` repository.

- The `egi-330/bin/pull-updates.sh` script has been updated to clone the `ccu-classes` repository and copy the `egi-330` subdirectory.
- The `egi-330/Dockerfile` has been updated to clone the `ccu-classes` repository and copy the `egi-330` subdirectory during initialization.
- The `egi-330/README.md` has been updated with the correct Dockerfile download link.
- The `csc-385/Dockerfile` has been updated to clone the `ccu-classes` repository and copy the `csc-385` subdirectory during initialization. The init script now follows the same pattern as the EGI-330 init script, the container's working directory is set to `/workspace`, and `rsync` is installed.
- A new `csc-385/bin/pull-updates.sh` script has been created to handle updates from the `ccu-classes` repository.
- The `csc-385/README.md` has been updated with the correct Dockerfile download link and machine-specific instructions for running Docker.