### PR TITLE
fix(csc-385): Correctly invoke javacc in Dockerfile

### DIFF
--- a/csc-385/Dockerfile
+++ b/csc-385/Dockerfile
@@ -37,7 +37,7 @@ ENV CLASSPATH="/opt/junit/junit-platform-console-standalone.jar:/opt/asm/asm-9.8
 
 # Create javacc wrapper script
 RUN echo '#!/bin/sh' > /usr/local/bin/javacc && \
-    echo 'java -jar /opt/javacc/javacc-7.0.13.jar "$@"' >> /usr/local/bin/javacc && \
+    echo 'java -cp /opt/javacc/javacc-7.0.13.jar org.javacc.parser.Main "$@"' >> /usr/local/bin/javacc && \
     chmod +x /usr/local/bin/javacc
 
 


### PR DESCRIPTION
This commit fixes an issue with the `javacc` installation in the `csc-385/Dockerfile`. The previous implementation used `java -jar` to run `javacc.jar`, which is not an executable jar.

This commit updates the `javacc` wrapper script to use `java -cp` with the correct main class (`org.javacc.parser.Main`), which allows `javacc` to be run from the command line.